### PR TITLE
Handle newlines in template user content

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
 jte {
     generate()
     binaryStaticContent = true
+    trimControlStructures = true
     packageName = "edu.kit.hci.soli.view.jte"
 }
 

--- a/src/main/java/edu/kit/hci/soli/config/template/JteConfiguration.java
+++ b/src/main/java/edu/kit/hci/soli/config/template/JteConfiguration.java
@@ -2,7 +2,6 @@ package edu.kit.hci.soli.config.template;
 
 import edu.kit.hci.soli.SoliApplication;
 import edu.kit.hci.soli.config.SoliConfiguration;
-import gg.jte.CodeResolver;
 import gg.jte.ContentType;
 import gg.jte.TemplateEngine;
 import gg.jte.resolve.DirectoryCodeResolver;
@@ -22,23 +21,24 @@ public class JteConfiguration {
 
     @Bean
     public TemplateEngine templateEngine(SoliConfiguration soliConfiguration) {
+        TemplateEngine templateEngine;
         if (soliConfiguration.isDevelopmentMode()) {
-            CodeResolver codeResolver = new DirectoryCodeResolver(Path.of("src", "main", "jte"));
-            TemplateEngine templateEngine = TemplateEngine.create(
-                    codeResolver,
+            templateEngine = TemplateEngine.create(
+                    new DirectoryCodeResolver(Path.of("src", "main", "jte")),
                     Paths.get("jte-classes"),
                     ContentType.Html,
                     SoliApplication.class.getClassLoader()
             );
-            templateEngine.setBinaryStaticContent(true);
-            return templateEngine;
         } else {
-            return TemplateEngine.createPrecompiled(
+            templateEngine = TemplateEngine.createPrecompiled(
                     null,
                     ContentType.Html,
                     null,
                     "edu.kit.hci.soli.view.jte"
             );
         }
+        templateEngine.setBinaryStaticContent(true);
+        templateEngine.setTrimControlStructures(true);
+        return templateEngine;
     }
 }

--- a/src/main/java/edu/kit/hci/soli/config/template/JteSoliTemplateOutput.java
+++ b/src/main/java/edu/kit/hci/soli/config/template/JteSoliTemplateOutput.java
@@ -1,0 +1,54 @@
+package edu.kit.hci.soli.config.template;
+
+import gg.jte.TemplateOutput;
+import gg.jte.html.HtmlTemplateOutput;
+import gg.jte.html.OwaspHtmlTemplateOutput;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+public class JteSoliTemplateOutput extends OwaspHtmlTemplateOutput {
+    private static final Set<String> nonNlTags = Set.of(
+            "script", // Parent class has special handling for script tags.
+            "textarea", // In HTML, the content of a textarea is taken as literal text. Do not insert line breaks.
+            "pre" // In HTML, the content of a pre tag is taken as literal text. Do not insert line breaks.
+    );
+
+    private final TemplateOutput templateOutput;
+
+    public JteSoliTemplateOutput(TemplateOutput templateOutput) {
+        super(templateOutput);
+        if (templateOutput instanceof HtmlTemplateOutput) {
+            throw new IllegalArgumentException("JteSoliTemplateOutput must not be used with HtmlTemplateOutput");
+        }
+        this.templateOutput = templateOutput;
+    }
+
+    private String tagName;
+    private String attributeName;
+
+    @Override
+    public void setContext(String tagName, String attributeName) {
+        super.setContext(tagName, attributeName);
+        this.tagName = tagName;
+        this.attributeName = attributeName;
+    }
+
+    @Override
+    public void writeUserContent(String value) {
+        if (value == null) return; // Prevent NPEs. This is the same behavior as in OwaspHtmlTemplateOutput.
+        if (tagName != null && attributeName != null) super.writeUserContent(value); // Attributes are handled by the parent class.
+        else if (nonNlTags.contains(tagName)) super.writeUserContent(value); // Some tags do not allow line breaks using <br>.
+        else {
+            // If this is normal HTML, escape it using the parent class but with line breaks inserted.
+            try (Stream<String> lines = value.lines()) {
+                AtomicBoolean first = new AtomicBoolean(true);
+                lines.forEach(line -> {
+                    if (!first.getAndSet(false)) templateOutput.writeUserContent("<br>");
+                    super.writeUserContent(line);
+                });
+            }
+        }
+    }
+}

--- a/src/main/java/edu/kit/hci/soli/config/template/JteView.java
+++ b/src/main/java/edu/kit/hci/soli/config/template/JteView.java
@@ -35,7 +35,7 @@ public class JteView extends AbstractTemplateView {
         model.put("context", new JteContext(context.getMessageSource(), soliConfiguration.getHostname(), context.getLocale(), soliConfiguration.getTimeZone()));
 
         Utf8ByteOutput output = new Utf8ByteOutput();
-        templateEngine.render(url, model, output);
+        templateEngine.render(url, model, new JteSoliTemplateOutput(output));
 
         response.setContentType(MediaType.TEXT_HTML_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());


### PR DESCRIPTION
In this, I have leaned heavily on the OWASP infrastructure already provided by JTE to (hopefully) prevent this from being a security problem.
Nonetheless, this has security implications, so please be extra thorough when reviewing.

Closes #157